### PR TITLE
Treat SCSS files changes as live CSS changes

### DIFF
--- a/ext/livereload.js
+++ b/ext/livereload.js
@@ -763,7 +763,7 @@
                         }
                     }
                     if (options.liveCSS) {
-                        if (path.match(/\.css$/i)) {
+                        if (path.match(/\.(css|scss)$/i)) {
                             if (this.reloadStylesheet(path)) {
                                 return;
                             }


### PR DESCRIPTION
Hey, great extension, been using it a lot lately! 

This PR allows people to save scss files and just have the stylesheets reload rather than triggering a full page reload the same way css file updates happen.  
Only works if you've added scss to the list of files to trigger too (`livereload.exts`) so it should be safe. 
What do you think?

*Tested locally & works well.*